### PR TITLE
Erweiterung Themen (Fragen anlegen und Ausgeben)

### DIFF
--- a/src/com/SoftwareProject/beuth/MainActivity.java
+++ b/src/com/SoftwareProject/beuth/MainActivity.java
@@ -82,7 +82,6 @@ public class MainActivity extends AppCompatActivity {
 		super.onCreate(savedInstanceState);
 		Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(this)); 
 		setContentView(R.layout.activity_main);
-		this.deleteDatabase("peat.db");
 	    dataSource = new PeatDataSource(this);
 	    Log.d(LOG_TAG, "Die Datenquelle wird geöffnet.");
 	    
@@ -141,7 +140,7 @@ public class MainActivity extends AppCompatActivity {
 				//}
 				try {
 				currentQuestion = dataSource.getNextQuestion();
-				stage.setText("Thema: " + currentQuestion.getQuestionTheme() + "           " + currentQuestion.getQuestionText());
+				stage.setText(currentQuestion.getQuestionTheme() + ":" + System.getProperty("line.separator") + currentQuestion.getQuestionText());
 				}
 				catch (IndexOutOfBoundsException e){
 					dataSource.resetUserHasQuestions();

--- a/src/com/SoftwareProject/beuth/PeatDataSource.java
+++ b/src/com/SoftwareProject/beuth/PeatDataSource.java
@@ -57,7 +57,13 @@ public class PeatDataSource {
         	}
         	execSQL("INSERT INTO Answers (as_idQuestions, as_text, as_isCorrect) VALUES ((SELECT MAX(idQuestions) FROM Questions WHERE qst_text='" + oQuestion.getQuestionText() + "'), '" + answers[i] + "', " + boolSqlite +")");
         }
-        execSQL("INSERT INTO " + dbHelper.TABLE_THEMES_HAS_QUESTIONS + " (thq_idQuestions, thq_idThemes) VALUES ((SELECT MAX(idQuestions) FROM Questions WHERE qst_text='" + oQuestion.getQuestionText() + "'), (SELECT MAX(idThemes) FROM Themes WHERE th_title='" + theme + "'))");
+        try {
+        	execSQL("INSERT INTO " + dbHelper.TABLE_THEMES_HAS_QUESTIONS + " (thq_idQuestions, thq_idThemes) VALUES ((SELECT MAX(idQuestions) FROM Questions WHERE qst_text='" + oQuestion.getQuestionText() + "'), (SELECT MAX(idThemes) FROM Themes WHERE th_title='" + theme + "'))"); 
+        }
+        catch (Exception e) {
+        	execSQL("INSERT INTO " + dbHelper.TABLE_THEMES + "(th_title) VALUES ('" + oQuestion.getQuestionTheme() + "')");
+        	execSQL("INSERT INTO " + dbHelper.TABLE_THEMES_HAS_QUESTIONS + " (thq_idQuestions, thq_idThemes) VALUES ((SELECT MAX(idQuestions) FROM Questions WHERE qst_text='" + oQuestion.getQuestionText() + "'), (SELECT MAX(idThemes) FROM Themes WHERE th_title='" + theme + "'))");
+        }
     }
     
     public void logAllTypes() {

--- a/src/com/SoftwareProject/beuth/QuestionInputActivity.java
+++ b/src/com/SoftwareProject/beuth/QuestionInputActivity.java
@@ -27,11 +27,12 @@ public class QuestionInputActivity extends AppCompatActivity {
 	Button backToMenu;
 	
 	private PeatDataSource dataSource;
+	private String[] themesArray;
 	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		String[] themesArray;
+		
 		// Initialisierung der SQLite-Datenbank
 		dataSource = new PeatDataSource(this);
 		// Verbindung mit der SQLite-Datenbank aufbauen

--- a/src/com/SoftwareProject/beuth/Splash.java
+++ b/src/com/SoftwareProject/beuth/Splash.java
@@ -19,6 +19,8 @@ public class Splash extends AppCompatActivity {
 		setContentView(R.layout.splash);
 		startSong = MediaPlayer.create(Splash.this, R.raw.splashsound);
 		startSong.start();
+		//In Produktion auskommentieren!
+		this.deleteDatabase("peat.db");
 		Thread timer = new Thread() {
 			public void run() {
 				try {


### PR DESCRIPTION
Aktuell kann das Thema frei eingegeben werden. Sollte es das Thema bereits geben, so wird es der neuen Fragen zugeordnet. Wenn es das Thema allerdings noch nicht gibt, so wird es angelegt.

Initialisierung der DB auf Splash verschoben

Ausgabe Thema beim Quiz verkürzt und Leerzeile zwischen Thema und Frage eingefügt
